### PR TITLE
bugfix: build: fix out of src build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,10 +110,10 @@ else
 seek_SOURCES+=fftwdummy.f
 endif
 
-sigproc.h: include.csh
-	./include.csh
-
 src=@top_srcdir@/src
+
+sigproc.h: include.csh
+	$(src)/include.csh
 
 monitor : mkmonitor.csh
 	$(src)/mkmonitor.csh >monitor


### PR DESCRIPTION
very small fix for broken out of src build.

another issue (not fixed):
non openmp supporting compilers (i.e. clang on mac osx) blow up in /Users/williamc/development/sigproc_mk/dev/checkout/src/mjk_cmd.h
code is ignoring the automake no open mp settings.