### PR TITLE
Allow filterbank_header to write headers when the machine is FAKE

### DIFF
--- a/src/filterbank_header.c
+++ b/src/filterbank_header.c
@@ -10,7 +10,7 @@ void filterbank_header(FILE *outptr) /* includefile */
   /* go no further here if not interested in header parameters */
   if (headerless) return;
   /* broadcast the header parameters to the output stream */
-  if (machine_id != 0) {
+  if (machine_id > -1) {
     send_string("HEADER_START");
     send_string("rawdatafile");
     send_string(inpfile);

--- a/src/readpsrfits_hd.c
+++ b/src/readpsrfits_hd.c
@@ -29,7 +29,7 @@ void readpsrfits_hd(char *filename,int *machine_id,int *telescope_id,int *data_t
   float ch_freq[MX_NCHAN];
 
   // Defaults that are not being set
-  *machine_id=-1;
+  *machine_id=0;
   *data_type = 0;
   *ibeam = 1;
   status=0;


### PR DESCRIPTION
There seems to have been a check for whether or not the machine is an actual machine, but ignoring the fact that not every machine has an alias and many pieces of software fallback and overwrite the machine ID with 0/FAKE when they don't recognise an input machine ID.

As a result, when the machine is set to FAKE, filterbank_header was silently refusing to write a header to disk (I ran into this as a side effect of trying to use filmerge, and finding my output filterbanks didn't have any headers). This changes the check to be such that the machine ID is greater than 0.

The only place where I can find that this is not the case is in the preparation of reading psrfits files, at readpsrfits_hd.c#32, which has been changed to 0 as a result to prevent this issue rearing it's head for someone else in the future.

There might be some internal logic I missed that sets the machine ID to 0 to indicate that the parameters are not setup, but I did not find such as case when I did a quick scan through the code base.