### PR TITLE
fix  gcc > 8 multiple definition error

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,7 +15,7 @@ endif
 endif
 endif
 
-
+AM_CFLAGS = -fcommon
 
 BUILT_SOURCES=sigproc.h
 


### PR DESCRIPTION
Multiple definition errors occur when a higher version of gcc is compiled.

Add ./src/Makefile.am
```
AM_CFLAGS = -fcommon
```