### PR TITLE
fix Error: Rank mismatch between actual argument for pgpoint function

### DIFF
--- a/src/best.f
+++ b/src/best.f
@@ -788,7 +788,7 @@ c                  xmin=parmin(1)
                   call pgpoint(ndm,x,y,17)
                else if (mode.eq.4.or.mode.eq.5) then
                   call pggray(grid,mg,mg,1,ngx,1,ngy,gridmax,gridmin,tr)
-                  call pgpoint(1,xx,yy,27)
+                  call pgpoint(1,[real(xx)],[real(yy)],27)
                   call pgsls(4)
                   call pgmove(xmin,0.0)
                   call pgdraw(xmax,0.0)

--- a/src/quickplot.f
+++ b/src/quickplot.f
@@ -495,7 +495,7 @@ c  Assumed that viewport and window defined outside routine
             if(k.gt.0)then
               x=i
               y=j
-              call pgpoint(1,x,y,ksym(k))
+              call pgpoint(1,[real(x)],[real(y)],ksym(k))
             endif
           enddo
         enddo


### PR DESCRIPTION
Fix call pgpoint function:
```
call pgpoint(1,xx,yy,27)
      |                                    1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
```