### PR TITLE
Fix PGPOINT scalar/array mismatch in best.f and quickplot.f

### DIFF
--- a/src/best.f
+++ b/src/best.f
@@ -52,6 +52,8 @@ c                 eg. is limited to 5 in one of my scripts.  50 is safe-ish
      &     xval(mg), yval(mg), gridmin, gridmax, deltax, deltay,
      &     xx, yy, fcentre, chbandw,zval(mg)
 
+      real :: x1(1), y1(1)
+      
       integer trid(mc),cidx(mc),i,j,k,l,sidx(mc),nids(mc),ndm
       integer narg,iargc,fld(mc),nsus,nf,mode,ix,iy,gidx,iz,bb
 
@@ -788,7 +790,9 @@ c                  xmin=parmin(1)
                   call pgpoint(ndm,x,y,17)
                else if (mode.eq.4.or.mode.eq.5) then
                   call pggray(grid,mg,mg,1,ngx,1,ngy,gridmax,gridmin,tr)
-                  call pgpoint(1,xx,yy,27)
+                  x1(1) = xx
+                  y1(1) = yy
+                  call pgpoint(1,x1,y1,27)
                   call pgsls(4)
                   call pgmove(xmin,0.0)
                   call pgdraw(xmax,0.0)

--- a/src/quickplot.f
+++ b/src/quickplot.f
@@ -461,6 +461,7 @@ c  Assumed that viewport and window defined outside routine
         parameter(nsym=10)
         integer*4 ksym(nsym)
         real*4 dat(nxd,nyd)
+        real x1(1), y1(1)
         data ksym/1,20,21,2,3,14,15,17,16,18/
 
         s=0.
@@ -490,14 +491,14 @@ c  Assumed that viewport and window defined outside routine
            call pgwindow(1.0,real(nx),0.0,real(ny+1))
         endif
         do j=1,ny
-          do i=1,nx
-            k=min(int((dat(i,j)-s)/rms),nsym)
-            if(k.gt.0)then
-              x=i
-              y=j
-              call pgpoint(1,x,y,ksym(k))
-            endif
-          enddo
+           do i=1,nx
+              k = min(int((dat(i,j)-s)/rms), nsym)
+              if (k .gt. 0) then
+                 x1(1) = i
+                 y1(1) = j
+                 call pgpoint(1, x1, y1, ksym(k))
+              endif
+           enddo
         enddo
 
         return


### PR DESCRIPTION
Trying to compile sigproc on Ubuntu 24.04 with gfortran GNU Fortran 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1), I was encountering errors such as:

```
f77 -fno-second-underscore -g -O2 -c -o best.o best.f
best.f:791:33:

  788 |                   call pgpoint(ndm,x,y,17)
      |                                   2
......
  791 |                   call pgpoint(1,xx,yy,27)
      |                                 1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
best.f:791:36:

  788 |                   call pgpoint(ndm,x,y,17)
      |                                     2
......
  791 |                   call pgpoint(1,xx,yy,27)
      |                                    1
Error: Rank mismatch between actual argument at (1) and actual argument at (2) (rank-1 and scalar)
make[3]: *** [Makefile:1689: best.o] Error 1
make[3]: Leaving directory '/home/ridolfi/SOFT/sigproc/src'
make[2]: *** [Makefile:1037: all] Error 2
make[2]: Leaving directory '/home/ridolfi/SOFT/sigproc/src'
make[1]: *** [Makefile:452: all-recursive] Error 1
make[1]: Leaving directory '/home/ridolfi/SOFT/sigproc'
make: *** [Makefile:384: all] Error 2
```

With the help of Copilot, I introduced the necessary fixes to `best.f` and `quickplot.f` for compilation to be successful.